### PR TITLE
Korjataan reititys pending-tilan aikana.

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -207,6 +207,9 @@ const App = () => {
       <Route
         path="/"
         element={
+          isPending ? (
+      <div>Loading...</div>
+    ) : (
           <Navigate
             to={
               userType === 'teacher'
@@ -217,6 +220,7 @@ const App = () => {
             }
             replace
           />
+          )
         }
       />
 


### PR DESCRIPTION
Selvitettiin johtuuko bugi käyttäjän poistamisessa staging-versiossa siitä, että reitityksen pending-tilaa ei varsinaisesti käsitellä: ohjelma ei ohjaudu millekkään sivulle, jos lataus ei tapahdu välittömästi.