### PR TITLE
Add version number visible in settings page

### DIFF
--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -217,6 +217,8 @@ export const SettingsPage = () => {
           </p>
         </div>
       </div>
+
+      <p className="text-right text-xs text-gray-500">Versio {__APP_VERSION__}</p> {/* Näytä (clientin) versio asetuksissa */}
     </div>
   )
 }

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { readFileSync } from 'fs'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version)
+  },
   plugins: [
     react(), 
     tailwindcss(),


### PR DESCRIPTION
Show app version number in the settings page (bottom right*).
Version is read from client/package.json at build time via Vite.

Future improvement: switch to git release tag (e.g. v1.1.17) injected
by GitHub Actions. This should be relatively simple.

Note: 16 pre-existing lint errors found (14 errors, 2 warnings).
Added to backlog as a separate task.