### PR TITLE
Add e2e tests for NotificationBanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,10 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Playwright
+e2e/playwright-report/
+e2e/test-results/
+
 # Claude
 CLAUDE.md
 

--- a/e2e/tests/notification-banner.spec.ts
+++ b/e2e/tests/notification-banner.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('NotificationBanner', () => {
+  test('error notification flow', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByPlaceholder('Sähköpostiosoite').fill('test@example.com')
+    await page.getByPlaceholder('Salasana').fill('incorrectpassword')
+    await page.getByRole('button', { name: /kirjaudu sisään/i }).click()
+
+    const alert = page.getByRole('alert')
+    await expect(alert).toBeVisible()
+    await expect(alert).toContainText('Virheellinen sähköposti tai salasana')
+
+    await page.getByRole('button', { name: /sulje ilmoitus/i }).click()
+    await expect(alert).not.toBeVisible()
+  })
+
+  test('success notification flow', async ({ page }) => {
+    await page.goto('/forgot-password')
+    await page.getByPlaceholder('Sähköpostiosoite').fill('test@example.com')
+    await page.getByRole('button', { name: /lähetä/i }).click()
+
+    const notification = page.getByText('Palautuslinkki lähetetty sähköpostiin')
+    await expect(notification).toBeVisible()
+    await expect(notification).not.toBeVisible({ timeout: 7000 })
+  })
+})

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test'
-
-test('login page is accessible', async ({ page }) => {
-  await page.goto('/login')
-  await expect(page.getByRole('button', { name: /kirjaudu sisään/i })).toBeVisible()
-})


### PR DESCRIPTION
Adds end-to-end tests for the NotificationBanner component to verify notification behaviour across error and success flows.

**Key changes:**

- Test error notification content and manual dismiss
- Test success notification auto-dismiss via password reset flow
- Remove `smoke.spec.ts` (covered by notification banner suite)
- Add Playwright output directories to `.gitignore`

Closes #12