### PR TITLE
Add E2E seed users via Playwright global setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Run E2E tests
         run: npm test
         working-directory: e2e
+        env:
+          E2E_MONGODB_URI: mongodb://admin:password@localhost:27018/viulumeri?authSource=admin
 
       - name: Upload Playwright report
         if: always()

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -2,6 +2,8 @@ services:
   mongodb:
     image: mongo:8
     container_name: viulumeri-e2e-mongodb
+    ports:
+      - '27018:27017'
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: password
@@ -19,6 +21,7 @@ services:
       - '3001:3001'
     environment:
       NODE_ENV: production
+      E2E_SEED: 'true'
       MONGODB_URI: mongodb://admin:password@mongodb:27017/viulumeri?authSource=admin
       BETTER_AUTH_SECRET: e2e-test-secret-key-for-ci-only
       BETTER_AUTH_URL: http://localhost:3001

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,48 @@
+import { request } from '@playwright/test'
+import { MongoClient } from 'mongodb'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3001'
+const MONGODB_URI =
+  process.env.E2E_MONGODB_URI ||
+  'mongodb://admin:password@localhost:27018/viulumeri?authSource=admin'
+
+const SEED_USERS = [
+  {
+    email: 'e2e-teacher@example.com',
+    password: 'E2eTeacher123!',
+    name: 'E2E Teacher',
+    userType: 'teacher',
+  },
+  {
+    email: 'e2e-student@example.com',
+    password: 'E2eStudent123!',
+    name: 'E2E Student',
+    userType: 'student',
+  },
+]
+
+export default async function globalSetup() {
+  const context = await request.newContext({ baseURL: BASE_URL })
+  const mongoClient = new MongoClient(MONGODB_URI)
+
+  try {
+    await mongoClient.connect()
+    const db = mongoClient.db()
+
+    for (const user of SEED_USERS) {
+      const existing = await db.collection('user').findOne({ email: user.email })
+      if (existing) {
+        continue
+      }
+
+      await context.post('/api/auth/sign-up/email', { data: user })
+
+      await db
+        .collection('user')
+        .updateOne({ email: user.email }, { $set: { emailVerified: true } })
+    }
+  } finally {
+    await mongoClient.close()
+    await context.dispose()
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,18 @@
       "version": "0.0.1",
       "devDependencies": {
         "@playwright/test": "^1.49.0",
-        "@types/node": "^22.0.0"
+        "@types/node": "^22.0.0",
+        "mongodb": "^6.18.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@playwright/test": {
@@ -36,6 +47,33 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -49,6 +87,71 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/playwright": {
@@ -83,10 +186,67 @@
         "node": ">=18"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,12 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "test": "playwright test",
+    "test": "E2E_MONGODB_URI=mongodb://admin:password@localhost:27017/viulumeri?authSource=admin playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "mongodb": "^6.18.0"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
+  globalSetup: './global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -104,10 +104,10 @@ Jos et pyytänyt tilin poistamista, voit jättää tämän viestin huomioimatta.
     }
   },
   emailVerification: {
-    sendOnSignUp: process.env.NODE_ENV !== 'test',
-    sendOnSignIn: process.env.NODE_ENV !== 'test',
+    sendOnSignUp: process.env.NODE_ENV !== 'test' && process.env.E2E_SEED !== 'true',
+    sendOnSignIn: process.env.NODE_ENV !== 'test' && process.env.E2E_SEED !== 'true',
     autoSignInAfterVerification: true,
-    sendVerificationEmail: process.env.NODE_ENV !== 'test'
+    sendVerificationEmail: process.env.NODE_ENV !== 'test' && process.env.E2E_SEED !== 'true'
       ? async ({ user, url }) => {
       logger.info('Sending verification email', {
         userId: user.id,


### PR DESCRIPTION
Adds a Playwright global setup that seeds E2E test users before tests run, enabling reliable login-based E2E tests without manual setup.

**Key changes:**

- New `global-setup.ts` that seeds a teacher and student user via the API and marks them as email-verified
- `E2E_SEED=true` env var on the app container skips sending verification emails during seeding
- Refactored `shouldSendAuthEmails` variable in `auth.ts` for consistency
- MongoDB port bound to `127.0.0.1` in `docker-compose.e2e.yml` to avoid exposing it on all interfaces
- `E2E_MONGODB_URI` passed to the CI E2E step so global setup can connect to the database

Closes #45