### PR TITLE
Admin can delete users

### DIFF
--- a/client/src/components/AdminPanel.tsx
+++ b/client/src/components/AdminPanel.tsx
@@ -137,7 +137,7 @@ export const AdminPanel = () => {
                 }
               }
             }}
-            disabled={deletingId === selectedUser.id}
+            disabled={Boolean(deletingId)}
             className="flex items-center gap-2 mt-4 bg-red-600 hover:bg-red-700 text-white rounded-md px-3 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Trash2 className="w-4 h-4" />

--- a/client/src/components/AdminPanel.tsx
+++ b/client/src/components/AdminPanel.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
-import { useAdminSummary, useAdminTeachers, useAdminStudents } from '../hooks/useAdmin'
+import { Trash2 } from 'lucide-react'
+import { useAdminSummary, useAdminTeachers, useAdminStudents, useDeleteAdminTeacher, useDeleteAdminStudent } from '../hooks/useAdmin'
 import { DropdownSearchbar } from './DropdownSearchbar'
+import { useNotification } from '../hooks/useNotification'
 import type { Teacher, Student } from '../services/admin'
 
 
@@ -19,6 +21,33 @@ export const AdminPanel = () => {
   const [searchUserInput, setSearchUserInput] = useState('')
   const [searchResults, setSearchResults] = useState<User[]>([])
   const [selectedUser, setSelectedUser] = useState<Teacher | Student | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const { showSuccess, showError } = useNotification()
+
+  const deleteTeacher = useDeleteAdminTeacher({
+    onSuccess: () => {
+      setSelectedUser(null)
+      setDeletingId(null)
+      showSuccess('Käyttäjä poistettu onnistuneesti')
+    },
+    onError: (error) => {
+      setDeletingId(null)
+      showError(`Virhe käyttäjän poistamisessa: ${error.message}`)
+    }
+  })
+
+  const deleteStudent = useDeleteAdminStudent({
+    onSuccess: () => {
+      setSelectedUser(null)
+      setDeletingId(null)
+      showSuccess('Käyttäjä poistettu onnistuneesti')
+    },
+    onError: (error) => {
+      setDeletingId(null)
+      showError(`Virhe käyttäjän poistamisessa: ${error.message}`)
+    }
+  })
 
   const teachers = teachersData?.teachers ?? []
   const students = studentsData?.students ?? []
@@ -96,6 +125,24 @@ export const AdminPanel = () => {
               </>
             )}
           </div>
+          <button
+            onClick={() => {
+              if (deletingId) return
+              if (confirm(`Haluatko varmasti poistaa käyttäjän ${selectedUser.name}? Toimintoa ei voi perua.`)) {
+                setDeletingId(selectedUser.id)
+                if ('studentCount' in selectedUser) {
+                  deleteTeacher.mutate(selectedUser.id)
+                } else {
+                  deleteStudent.mutate(selectedUser.id)
+                }
+              }
+            }}
+            disabled={deletingId === selectedUser.id}
+            className="flex items-center gap-2 mt-4 bg-red-600 hover:bg-red-700 text-white rounded-md px-3 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Trash2 className="w-4 h-4" />
+            {deletingId === selectedUser.id ? 'Poistetaan...' : 'Poista käyttäjä'}
+          </button>
         </div>
       )}
     </div>

--- a/client/src/hooks/useAdmin.ts
+++ b/client/src/hooks/useAdmin.ts
@@ -35,11 +35,12 @@ export const useDeleteAdminTeacher = (
 
   return useMutation({
     mutationFn: adminService.deleteTeacher,
-    onSuccess: () => {
+    ...options,
+    onSuccess: (...args) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'teachers'] })
       queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] })
+      options?.onSuccess?.(...args)
     },
-    ...options
   })
 }
 
@@ -50,10 +51,11 @@ export const useDeleteAdminStudent = (
 
   return useMutation({
     mutationFn: adminService.deleteStudent,
-    onSuccess: () => {
+    ...options,
+    onSuccess: (...args) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'students'] })
       queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] })
+      options?.onSuccess?.(...args)
     },
-    ...options
   })
 }

--- a/client/src/hooks/useAdmin.ts
+++ b/client/src/hooks/useAdmin.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, type UseQueryOptions, type UseMutationOptions } from '@tanstack/react-query'
 import { adminService, type SummaryResponse, type Teacher, type Student } from '../services/admin'
 
 export const useAdminSummary = (
@@ -27,3 +27,33 @@ export const useAdminStudents = (
     queryFn: adminService.getAdminStudents,
     ...options
   })
+
+export const useDeleteAdminTeacher = (
+  options?: UseMutationOptions<void, Error, string>
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: adminService.deleteTeacher,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'teachers'] })
+      queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] })
+    },
+    ...options
+  })
+}
+
+export const useDeleteAdminStudent = (
+  options?: UseMutationOptions<void, Error, string>
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: adminService.deleteStudent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'students'] })
+      queryClient.invalidateQueries({ queryKey: ['admin', 'summary'] })
+    },
+    ...options
+  })
+}

--- a/client/src/services/admin.ts
+++ b/client/src/services/admin.ts
@@ -60,6 +60,18 @@ export const adminService = {
     await axios.delete('/api/admin/popup-messages', {
       withCredentials: true
     })
+  },
+
+  deleteTeacher: async (id: string): Promise<void> => {
+    await axios.delete(`/api/admin/teachers/${id}`, {
+      withCredentials: true
+    })
+  },
+
+  deleteStudent: async (id: string): Promise<void> => {
+    await axios.delete(`/api/admin/students/${id}`, {
+      withCredentials: true
+    })
   }
 }
 

--- a/server/src/controllers/admin.ts
+++ b/server/src/controllers/admin.ts
@@ -63,15 +63,15 @@ adminRouter.delete('/teachers/:teacherId', async (request, response) => {
     return response.status(404).json({ error: 'Teacher not found' })
   }
 
+  await auth.api.removeUser({
+    body: { userId: teacher.userId },
+    headers: fromNodeHeaders(request.headers)
+  })
   await Student.updateMany(
     { teacher: teacher.id },
     { $unset: { teacher: 1 } }
   )
   await teacher.deleteOne()
-  await auth.api.removeUser({
-    body: { userId: teacher.userId },
-    headers: fromNodeHeaders(request.headers)
-  })
 
   response.status(204).send()
 })
@@ -92,12 +92,12 @@ adminRouter.delete('/students/:studentId', async (request, response) => {
     }
   }
 
-  await Homework.deleteMany({ student: student.id })
-  await student.deleteOne()
   await auth.api.removeUser({
     body: { userId: student.userId },
     headers: fromNodeHeaders(request.headers)
   })
+  await Homework.deleteMany({ student: student.id })
+  await student.deleteOne()
 
   response.status(204).send()
 })

--- a/server/src/controllers/admin.ts
+++ b/server/src/controllers/admin.ts
@@ -1,6 +1,8 @@
 /// <reference path="../types/express.d.ts" />
 import { Router } from 'express'
+import { fromNodeHeaders } from 'better-auth/node'
 import { requireAdmin } from '../utils/auth-middleware'
+import { auth } from '../utils/auth'
 import Teacher from '../models/teacher'
 import Student from '../models/student'
 import Homework from '../models/homework'
@@ -65,8 +67,11 @@ adminRouter.delete('/teachers/:teacherId', async (request, response) => {
     { teacher: teacher.id },
     { $unset: { teacher: 1 } }
   )
-  await Homework.deleteMany({ teacher: teacher.id })
   await teacher.deleteOne()
+  await auth.api.removeUser({
+    body: { userId: teacher.userId },
+    headers: fromNodeHeaders(request.headers)
+  })
 
   response.status(204).send()
 })
@@ -89,6 +94,10 @@ adminRouter.delete('/students/:studentId', async (request, response) => {
 
   await Homework.deleteMany({ student: student.id })
   await student.deleteOne()
+  await auth.api.removeUser({
+    body: { userId: student.userId },
+    headers: fromNodeHeaders(request.headers)
+  })
 
   response.status(204).send()
 })

--- a/server/src/tests/admin.test.ts
+++ b/server/src/tests/admin.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert'
+import { TestHelper } from '../utils/testHelper'
+import supertest from 'supertest'
+import app from '../app'
+import Teacher from '../models/teacher'
+import Student from '../models/student'
+import Homework from '../models/homework'
+
+const api = supertest(app)
+
+before(async () => {
+  await TestHelper.setupTestDatabase()
+})
+
+beforeEach(async () => {
+  await TestHelper.clearDatabase()
+})
+
+after(async () => {
+  await TestHelper.cleanup()
+})
+
+describe('DELETE /api/admin/teachers/:teacherId', () => {
+  it('should return 403 Forbidden for non-admin', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedTeacher(api)
+
+    const response = await api
+      .delete('/api/admin/teachers/000000000000000000000000')
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 403)
+    assert.strictEqual(response.body.error, 'Admin role required')
+  })
+
+  it('should return 404 when teacher not found', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+
+    const response = await api
+      .delete('/api/admin/teachers/000000000000000000000000')
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 404)
+    assert.strictEqual(response.body.error, 'Teacher not found')
+  })
+
+  it('should return 204 and delete the teacher document', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser } = await TestHelper.createAuthenticatedTeacher(api)
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+
+    const response = await api
+      .delete(`/api/admin/teachers/${teacher!.id}`)
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 204)
+    const deletedTeacher = await Teacher.findById(teacher!.id)
+    assert.strictEqual(deletedTeacher, null)
+  })
+
+  it('should unlink students from the deleted teacher', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser } = await TestHelper.createAuthenticatedTeacher(api)
+    const { user: studentUser } = await TestHelper.createAuthenticatedStudent(api)
+
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    student!.teacher = teacher!.id
+    teacher!.students.push(student!.id)
+    await student!.save()
+    await teacher!.save()
+
+    await api
+      .delete(`/api/admin/teachers/${teacher!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const updatedStudent = await Student.findById(student!.id)
+    assert.strictEqual(updatedStudent!.teacher, null)
+  })
+
+  it('should not delete homework when teacher is deleted', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser } = await TestHelper.createAuthenticatedTeacher(api)
+    const { user: studentUser } = await TestHelper.createAuthenticatedStudent(api)
+
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    await Homework.create({ teacher: teacher!.id, student: student!.id, songs: [] })
+
+    await api
+      .delete(`/api/admin/teachers/${teacher!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const remainingHomework = await Homework.find({ student: student!.id })
+    assert.strictEqual(remainingHomework.length, 1)
+  })
+
+  it('should delete the teacher Better Auth account', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser, email, password } =
+      await TestHelper.createAuthenticatedTeacher(api)
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+
+    await api
+      .delete(`/api/admin/teachers/${teacher!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const signInResponse = await api
+      .post('/api/auth/sign-in/email')
+      .send({ email, password })
+
+    assert.notStrictEqual(signInResponse.status, 200)
+  })
+})
+
+describe('DELETE /api/admin/students/:studentId', () => {
+  it('should return 403 Forbidden for non-admin', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedTeacher(api)
+
+    const response = await api
+      .delete('/api/admin/students/000000000000000000000000')
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 403)
+    assert.strictEqual(response.body.error, 'Admin role required')
+  })
+
+  it('should return 404 when student not found', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+
+    const response = await api
+      .delete('/api/admin/students/000000000000000000000000')
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 404)
+    assert.strictEqual(response.body.error, 'Student not found')
+  })
+
+  it('should return 204 and delete the student document', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: studentUser } = await TestHelper.createAuthenticatedStudent(api)
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    const response = await api
+      .delete(`/api/admin/students/${student!.id}`)
+      .set('Cookie', sessionCookie)
+
+    assert.strictEqual(response.status, 204)
+    const deletedStudent = await Student.findById(student!.id)
+    assert.strictEqual(deletedStudent, null)
+  })
+
+  it('should remove the student from the teacher students array', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser } = await TestHelper.createAuthenticatedTeacher(api)
+    const { user: studentUser } = await TestHelper.createAuthenticatedStudent(api)
+
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    student!.teacher = teacher!.id
+    teacher!.students.push(student!.id)
+    await student!.save()
+    await teacher!.save()
+
+    await api
+      .delete(`/api/admin/students/${student!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const updatedTeacher = await Teacher.findById(teacher!.id)
+    assert.strictEqual(updatedTeacher!.students.length, 0)
+  })
+
+  it('should delete homework when student is deleted', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: teacherUser } = await TestHelper.createAuthenticatedTeacher(api)
+    const { user: studentUser } = await TestHelper.createAuthenticatedStudent(api)
+
+    const teacher = await Teacher.findOne({ userId: teacherUser.id })
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    await Homework.create({ teacher: teacher!.id, student: student!.id, songs: [] })
+
+    await api
+      .delete(`/api/admin/students/${student!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const remainingHomework = await Homework.find({ student: student!.id })
+    assert.strictEqual(remainingHomework.length, 0)
+  })
+
+  it('should delete the student Better Auth account', async () => {
+    const { sessionCookie } = await TestHelper.createAuthenticatedAdmin(api)
+    const { user: studentUser, email, password } =
+      await TestHelper.createAuthenticatedStudent(api)
+    const student = await Student.findOne({ userId: studentUser.id })
+
+    await api
+      .delete(`/api/admin/students/${student!.id}`)
+      .set('Cookie', sessionCookie)
+
+    const signInResponse = await api
+      .post('/api/auth/sign-in/email')
+      .send({ email, password })
+
+    assert.notStrictEqual(signInResponse.status, 200)
+  })
+})

--- a/server/src/utils/testHelper.ts
+++ b/server/src/utils/testHelper.ts
@@ -163,6 +163,35 @@ export class TestHelper {
     }
   }
 
+  static async createAuthenticatedAdmin(
+    api: any,
+    email?: string,
+    name?: string
+  ) {
+    const userData = {
+      email: email || `test-admin-${Date.now()}@example.com`,
+      name: name || 'Test Admin',
+      userType: 'teacher' as const
+    }
+
+    const { password } = await this.signUpUser(api, userData)
+
+    const db = this.client!.db()
+    await db
+      .collection('user')
+      .updateOne({ email: userData.email }, { $set: { emailVerified: true, role: 'admin' } })
+
+    const signInResponse = await this.signInUser(api, userData.email, password)
+    const sessionCookie = this.extractSessionCookie(signInResponse)
+
+    return {
+      user: signInResponse.body.user,
+      sessionCookie,
+      email: userData.email,
+      password
+    }
+  }
+
   static async makeAuthenticatedRequest(
     api: any,
     method: 'get' | 'post' | 'put' | 'delete',

--- a/server/src/utils/testHelper.ts
+++ b/server/src/utils/testHelper.ts
@@ -177,9 +177,13 @@ export class TestHelper {
     const { password } = await this.signUpUser(api, userData)
 
     const db = this.client!.db()
-    await db
+    const result = await db
       .collection('user')
       .updateOne({ email: userData.email }, { $set: { emailVerified: true, role: 'admin' } })
+
+    if (result.matchedCount === 0) {
+      throw new Error(`createAuthenticatedAdmin: user not found in DB for email ${userData.email}`)
+    }
 
     const signInResponse = await this.signInUser(api, userData.email, password)
     const sessionCookie = this.extractSessionCookie(signInResponse)


### PR DESCRIPTION
Adds admin user deletion for teachers and students.

**Key changes:**

- Admin can delete users via a confirmation dialog in `AdminPanel`
- Deleting a teacher unlinks their students but preserves homework
- Deleting a student removes all their homework and unlinks them from their teacher
- User's Better Auth account is fully removed alongside all associated data
- Non-admin requests to delete endpoints return 403 Forbidden
- Success and failure feedback shown via the notification banner
- Integration tests added for different delete scenarios

Closes #41