### PR TITLE
Add lint to server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11777,6 +11777,7 @@
         "uncrypto": "^0.1.3"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
@@ -11785,11 +11786,13 @@
         "@types/react-dom": "^19.1.7",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.25.0",
+        "globals": "^17.6.0",
         "nodemon": "^3.1.10",
         "prettier": "^3.3.3",
         "supertest": "^7.1.4",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.60.0"
       }
     },
     "server/node_modules/@noble/ciphers": {
@@ -11800,6 +11803,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "server/node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -1,0 +1,15 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+  },
+)

--- a/server/package.json
+++ b/server/package.json
@@ -10,11 +10,13 @@
     "test": "NODE_ENV=test TS_NODE_PROJECT=tsconfig.test.json node --require ts-node/register --test --test-concurrency=1 src/tests/*.test.ts",
     "test:watch": "NODE_ENV=test TS_NODE_PROJECT=tsconfig.test.json node --require ts-node/register --test --watch src/tests/*.test.ts",
     "test:students": "NODE_ENV=test TS_NODE_PROJECT=tsconfig.test.json node --require ts-node/register --test src/tests/students.test.ts",
-    "healthcheck": "tsc --noEmit"
+    "healthcheck": "tsc --noEmit",
+    "lint": "eslint src"
   },
   "author": "Jasse Merivirta",
   "license": "UNLICENSED",
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
@@ -23,11 +25,13 @@
     "@types/react-dom": "^19.1.7",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.25.0",
+    "globals": "^17.6.0",
     "nodemon": "^3.1.10",
     "prettier": "^3.3.3",
     "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.60.0"
   },
   "dependencies": {
     "@noble/ciphers": "^1.3.0",


### PR DESCRIPTION
Adds ESLint with TypeScript support to the server.

**Key changes:**
- Added `eslint.config.mjs` with config using `@eslint/js`, `typescript-eslint`, and `globals.node`
- Added `lint` script to `package.json` running `eslint src`
- Added dev dependencies: `@eslint/js`, `globals`, `typescript-eslint`

Closes #100