### PR TITLE
Add lint to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,27 @@ on:
     branches: [main, dev]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint server
+        run: npm run lint --workspace=server
+
+      - name: Lint client
+        run: npm run lint --workspace=client
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -59,6 +59,10 @@ export const SettingsPage = () => {
     }
   })
 
+  useEffect(() => {
+    faqService.getFaqs().then(setFaqs)
+  }, [])
+
   if (isPending) {
     return <div>Ladataan...</div>
   }
@@ -105,11 +109,7 @@ export const SettingsPage = () => {
     logout.mutate()
   }
 
-  useEffect(() => {
-  faqService.getFaqs().then(setFaqs)
-}, [])
-
-const visibleFaqs = faqs
+  const visibleFaqs = faqs
   .filter((faq) => faq.question.trim())
   .sort(
     (a, b) =>

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -60,8 +60,11 @@ export const SettingsPage = () => {
   })
 
   useEffect(() => {
-    faqService.getFaqs().then(setFaqs)
-  }, [])
+    if (isPending || !session) return
+    faqService.getFaqs().then(setFaqs).catch(error => {
+      showError(`Virhe FAQ:ien lataamisessa: ${error.message}`)
+    })
+  }, [isPending, session, showError])
 
   if (isPending) {
     return <div>Ladataan...</div>


### PR DESCRIPTION
Adds a lint job to the CI pipeline that runs ESLint for both the server and client on every pull request. Also fixes a lint error found in [SettingsPage.tsx](https://github.com/viulumeri/viulumeri/blob/95-add-lint-to-ci-pipeline/client/src/components/SettingsPage.tsx).

Closes #95