### PR TITLE
Show YouTube links as embeds

### DIFF
--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useMemo } from 'react'
 import DOMPurify from 'dompurify'
 import { processYouTubeEmbeds } from '../utils/youtubeEmbed'
 import { Ellipsis, X } from 'lucide-react'
@@ -49,6 +49,11 @@ const HomeworkCard = ({
   onAddSong
 }: Props) => {
   const menuRef = useRef<HTMLDivElement | null>(null)
+
+  const renderedComment = useMemo(
+    () => processYouTubeEmbeds(DOMPurify.sanitize(hw.comment ?? '', { ADD_ATTR: ['target'] })),
+    [hw.comment]
+  )
 
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
@@ -179,7 +184,7 @@ const HomeworkCard = ({
                 [&_li]:my-0.5
                 [&_a]:text-blue-400 [&_a]:underline
                 [&_iframe]:w-full [&_iframe]:aspect-video [&_iframe]:rounded [&_iframe]:mt-2"
-                dangerouslySetInnerHTML={{ __html: processYouTubeEmbeds(DOMPurify.sanitize(hw.comment, { ADD_ATTR: ['target'] })) }}
+                dangerouslySetInnerHTML={{ __html: renderedComment }}
               />
             </>
           )

--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import DOMPurify from 'dompurify'
+import { processYouTubeEmbeds } from '../utils/youtubeEmbed'
 import { Ellipsis, X } from 'lucide-react'
 import type { SongListItem, HomeworkListResponse } from '../../../shared/types'
 import SongCard from './SongCard'
@@ -177,7 +178,7 @@ const HomeworkCard = ({
                 [&_ol_ol_ol]:list-[lower-roman]
                 [&_li]:my-0.5
                 [&_a]:text-blue-400 [&_a]:underline"
-                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(hw.comment, { ADD_ATTR: ['target'] }) }}
+                dangerouslySetInnerHTML={{ __html: processYouTubeEmbeds(DOMPurify.sanitize(hw.comment, { ADD_ATTR: ['target'] })) }}
               />
             </>
           )

--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -177,7 +177,8 @@ const HomeworkCard = ({
                 [&_ol_ol]:list-[lower-alpha]
                 [&_ol_ol_ol]:list-[lower-roman]
                 [&_li]:my-0.5
-                [&_a]:text-blue-400 [&_a]:underline"
+                [&_a]:text-blue-400 [&_a]:underline
+                [&_iframe]:w-full [&_iframe]:aspect-video [&_iframe]:rounded [&_iframe]:mt-2"
                 dangerouslySetInnerHTML={{ __html: processYouTubeEmbeds(DOMPurify.sanitize(hw.comment, { ADD_ATTR: ['target'] })) }}
               />
             </>

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -1,14 +1,28 @@
 export const extractYouTubeVideoId = (url: string): string | null => {
-  const patterns = [
-    /(?:youtube\.com\/watch\?(?:.*&)?v=)([a-zA-Z0-9_-]{11})/,
-    /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
-    /(?:youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
-    /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
-  ]
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
 
-  for (const pattern of patterns) {
-    const match = url.match(pattern)
-    if (match) return match[1]
+  const host = parsed.hostname.replace(/^www\./, '')
+  const path = parsed.pathname
+
+  if (host === 'youtube.com') {
+    if (path === '/watch') {
+      const v = parsed.searchParams.get('v')
+      return v && /^[a-zA-Z0-9_-]{11}$/.test(v) ? v : null
+    }
+    if (path.startsWith('/shorts/') || path.startsWith('/embed/')) {
+      const id = path.split('/')[2]
+      return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null
+    }
+  }
+
+  if (host === 'youtu.be') {
+    const id = path.slice(1)
+    return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null
   }
 
   return null

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -39,6 +39,8 @@ export const processYouTubeEmbeds = (html: string): string => {
 
     const iframe = doc.createElement('iframe')
     iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}`
+    iframe.title = anchor.textContent?.trim() || 'YouTube video'
+    iframe.loading = 'lazy'
     iframe.allowFullscreen = true
     iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture')
 

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -1,0 +1,15 @@
+export const extractYouTubeVideoId = (url: string): string | null => {
+  const patterns = [
+    /(?:youtube\.com\/watch\?(?:.*&)?v=)([a-zA-Z0-9_-]{11})/,
+    /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+    /(?:youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
+    /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+  ]
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern)
+    if (match) return match[1]
+  }
+
+  return null
+}

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -13,3 +13,23 @@ export const extractYouTubeVideoId = (url: string): string | null => {
 
   return null
 }
+
+export const processYouTubeEmbeds = (html: string): string => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+
+  doc.querySelectorAll('a[href]').forEach((el) => {
+    const anchor = el as HTMLAnchorElement
+    const videoId = extractYouTubeVideoId(anchor.href)
+    if (!videoId) return
+
+    const iframe = doc.createElement('iframe')
+    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}`
+    iframe.allowFullscreen = true
+    iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture')
+
+    anchor.replaceWith(iframe)
+  })
+
+  return doc.body.innerHTML
+}

--- a/e2e/tests/homework-comment-formatting.spec.ts
+++ b/e2e/tests/homework-comment-formatting.spec.ts
@@ -243,10 +243,11 @@ test.describe.serial('Homework comment formatting', () => {
   })
 
   test('multiple YouTube links are each shown as separate embeds', async ({ browser }) => {
-    // Covers youtube.com/watch and youtu.be link formats
+    // Covers youtube.com/watch, youtu.be, and youtube.com/shorts link formats
     await setComment(
       '<p><a href="https://www.youtube.com/watch?v=testVidId01">video yksi</a></p>' +
-        '<p><a href="https://youtu.be/testVidId02">video kaksi</a></p>'
+        '<p><a href="https://youtu.be/testVidId02">video kaksi</a></p>' +
+        '<p><a href="https://www.youtube.com/shorts/testVidId03">video kolme</a></p>'
     )
 
     const studentPage = await browser.newPage()
@@ -258,6 +259,9 @@ test.describe.serial('Homework comment formatting', () => {
     ).toBeVisible()
     await expect(
       studentPage.locator('iframe[src*="youtube-nocookie.com/embed/testVidId02"]')
+    ).toBeVisible()
+    await expect(
+      studentPage.locator('iframe[src*="youtube-nocookie.com/embed/testVidId03"]')
     ).toBeVisible()
 
     await studentPage.close()

--- a/e2e/tests/homework-comment-formatting.spec.ts
+++ b/e2e/tests/homework-comment-formatting.spec.ts
@@ -46,7 +46,8 @@ test.beforeAll(async () => {
     expect(existingHwRes.ok()).toBeTruthy()
     const { homework: existingHomework } = await existingHwRes.json()
     for (const hw of existingHomework) {
-      await teacherCtx.delete(`/api/homework/${hw.id}`)
+      const deleteRes = await teacherCtx.delete(`/api/homework/${hw.id}`)
+      expect(deleteRes.ok()).toBeTruthy()
     }
 
     // Create a homework assignment for the student

--- a/e2e/tests/homework-comment-formatting.spec.ts
+++ b/e2e/tests/homework-comment-formatting.spec.ts
@@ -41,6 +41,14 @@ test.beforeAll(async () => {
     expect(student).toBeDefined()
     studentId = student.id
 
+    // Delete any leftover homework from previous runs
+    const existingHwRes = await teacherCtx.get(`/api/students/${studentId}/homework`)
+    expect(existingHwRes.ok()).toBeTruthy()
+    const { homework: existingHomework } = await existingHwRes.json()
+    for (const hw of existingHomework) {
+      await teacherCtx.delete(`/api/homework/${hw.id}`)
+    }
+
     // Create a homework assignment for the student
     const hwRes = await teacherCtx.post('/api/homework', {
       data: { studentId, songs: [], comment: '' },
@@ -80,7 +88,27 @@ async function loginAs(
   await markStartupAnnouncementsAsSeen(page, credentials.email)
 }
 
-test.describe('Homework comment formatting', () => {
+// Set the homework comment HTML directly via the API (teacher auth)
+async function setComment(comment: string) {
+  const teacherCtx = await request.newContext({ baseURL: BASE_URL })
+  try {
+    const signInRes = await teacherCtx.post('/api/auth/sign-in/email', { data: TEACHER })
+    expect(signInRes.ok()).toBeTruthy()
+    const putRes = await teacherCtx.put(`/api/homework/${homeworkId}`, {
+      data: { comment },
+    })
+    expect(putRes.ok()).toBeTruthy()
+  } finally {
+    await teacherCtx.dispose()
+  }
+}
+
+test.describe.serial('Homework comment formatting', () => {
+  test.beforeEach(async () => {
+    // Reset the comment so each test starts from a clean slate
+    await setComment('')
+  })
+
   test('teacher saves formatted comment and student sees it as rendered HTML', async ({
     page,
     browser,
@@ -93,51 +121,54 @@ test.describe('Homework comment formatting', () => {
     await editor.waitFor()
     await editor.click()
 
-    // Select "Otsikko" from the toolbar dropdown
-    await page.locator('select').selectOption('2')
-    await page.keyboard.type('Harjoitteluohje')
+    // Heading via keyboard shortcut
+    await page.keyboard.press('Control+Alt+2')
+    await page.keyboard.type('Harjoitteluohje', { delay: 25 })
+    await expect(editor.locator('h2').filter({ hasText: 'Harjoitteluohje' })).toBeAttached()
     await page.keyboard.press('Enter')
-    await page.locator('select').selectOption('0')
 
     // Italic
     await page.keyboard.press('Control+i')
-    await page.keyboard.type('Tärkeää:')
+    await page.keyboard.type('Tärkeää:', { delay: 25 })
     await page.keyboard.press('Control+i')
+    await expect(editor.locator('em').filter({ hasText: 'Tärkeää:' })).toBeAttached()
     await page.keyboard.press('Enter')
 
     // Bold
     await page.keyboard.press('Control+b')
-    await page.keyboard.type('muista harjoitella')
+    await page.keyboard.type('muista harjoitella', { delay: 25 })
     await page.keyboard.press('Control+b')
+    await expect(editor.locator('strong').filter({ hasText: 'muista harjoitella' })).toBeAttached()
     await page.keyboard.press('Enter')
 
     // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
     await page.getByTitle('Lista', { exact: true }).click()
     await editor.focus()
-    await page.keyboard.type('Ohje yksi')
-    await page.keyboard.press('Enter')
-    await page.keyboard.type('Ohje kaksi')
-    await page.keyboard.press('Enter')
-    await page.keyboard.press('Enter')
-
-    // Verify list was actually created in the editor before saving
+    await page.keyboard.type('Ohje yksi', { delay: 25 })
     await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Ohje kaksi', { delay: 25 })
+    await expect(editor.locator('ul li').filter({ hasText: 'Ohje kaksi' })).toBeAttached()
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Enter')
 
     // Ordered list — same pattern
     await page.getByTitle('Numeroitu lista').click()
     await editor.focus()
-    await page.keyboard.type('Vaihe yksi')
+    await page.keyboard.type('Vaihe yksi', { delay: 25 })
+    await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
     await page.keyboard.press('Enter')
     await page.keyboard.press('Enter')
 
     // Link
-    await page.keyboard.type('nettisivu')
+    await page.keyboard.type('nettisivu', { delay: 25 })
     await page.keyboard.press('Home')
     await page.keyboard.press('Shift+End')
     await page.getByTitle('Linkki').click()
     // Dialog has two inputs: display text (auto-focused) and URL (second)
     await page.locator('.inset-0 input').nth(1).fill('example.com')
     await page.getByRole('button', { name: 'Tallenna' }).click()
+    await expect(editor.locator('a').filter({ hasText: 'nettisivu' })).toBeAttached()
 
     // Save homework
     await page.locator('button.rounded-full.bg-white').click()
@@ -175,6 +206,58 @@ test.describe('Homework comment formatting', () => {
     await expect(studentPage.getByText('<strong>')).not.toBeVisible()
     await expect(studentPage.getByText('<h2>')).not.toBeVisible()
     await expect(studentPage.getByText('<a href')).not.toBeVisible()
+
+    await studentPage.close()
+  })
+
+  test('YouTube link is shown as an embed and non-YouTube link stays as a link', async ({
+    browser,
+  }) => {
+    // YouTube IDs are fake but valid 11-char shapes
+    await setComment(
+      '<p><a href="https://www.youtube.com/watch?v=testVidId01">katso video</a></p>' +
+        '<p><a href="https://example.com">nettisivu</a></p>'
+    )
+
+    const studentPage = await browser.newPage()
+    await loginAs(studentPage, STUDENT, /\/student\//)
+    await studentPage.goto('/student/homework/list')
+
+    await expect(studentPage.getByText('Opettajan kommentti')).toBeVisible()
+
+    // YouTube link rendered as iframe embed
+    await expect(
+      studentPage.locator('iframe[src*="youtube-nocookie.com/embed/testVidId01"]')
+    ).toBeVisible()
+
+    // YouTube anchor link should not be present
+    await expect(studentPage.locator('a[href*="youtube.com"]')).not.toBeAttached()
+
+    // Non-YouTube link still rendered as anchor
+    await expect(
+      studentPage.locator('a[href="https://example.com"]').filter({ hasText: 'nettisivu' })
+    ).toBeVisible()
+
+    await studentPage.close()
+  })
+
+  test('multiple YouTube links are each shown as separate embeds', async ({ browser }) => {
+    // Covers youtube.com/watch and youtu.be link formats
+    await setComment(
+      '<p><a href="https://www.youtube.com/watch?v=testVidId01">video yksi</a></p>' +
+        '<p><a href="https://youtu.be/testVidId02">video kaksi</a></p>'
+    )
+
+    const studentPage = await browser.newPage()
+    await loginAs(studentPage, STUDENT, /\/student\//)
+    await studentPage.goto('/student/homework/list')
+
+    await expect(
+      studentPage.locator('iframe[src*="youtube-nocookie.com/embed/testVidId01"]')
+    ).toBeVisible()
+    await expect(
+      studentPage.locator('iframe[src*="youtube-nocookie.com/embed/testVidId02"]')
+    ).toBeVisible()
 
     await studentPage.close()
   })


### PR DESCRIPTION
Adds YouTube video embedding in homework comments.

**Key changes:**

- YouTube links added by the teacher are automatically replaced with embedded video players when the comment is viewed
- Supports `youtube.com/watch`, `youtu.be`, and `youtube.com/shorts` URL formats
- Non-YouTube links are left unchanged
- New `youtubeEmbed.ts` utility handles URL parsing and iframe replacement
- E2E tests added for single embed, multiple embeds, and non-YouTube links

Closes #117