### PR TITLE
Fix YouTube video handling in homework comments

### DIFF
--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useMemo } from 'react'
 import DOMPurify from 'dompurify'
-import { processYouTubeEmbeds } from '../utils/youtubeEmbed'
+import { processYouTubeEmbeds, pauseYouTubeIframes } from '../utils/youtubeEmbed'
 import { Ellipsis, X } from 'lucide-react'
 import type { SongListItem, HomeworkListResponse } from '../../../shared/types'
 import SongCard from './SongCard'
@@ -49,6 +49,7 @@ const HomeworkCard = ({
   onAddSong
 }: Props) => {
   const menuRef = useRef<HTMLDivElement | null>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
 
   const renderedComment = useMemo(
     () => processYouTubeEmbeds(DOMPurify.sanitize(hw.comment ?? '', { ADD_ATTR: ['target'] })),
@@ -68,8 +69,21 @@ const HomeworkCard = ({
     return () => document.removeEventListener('click', onDocClick)
   }, [isMenuOpen, onToggleMenu])
 
+  useEffect(() => {
+    const el = cardRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) pauseYouTubeIframes(el)
+      },
+      { threshold: 0 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <div className="snap-center w-[90vw] max-w-4xl flex-shrink-0 rounded-lg pt-4 pb-4 px-8 relative ">
+    <div ref={cardRef} className="snap-center w-[90vw] max-w-4xl flex-shrink-0 rounded-lg pt-4 pb-4 px-8 relative ">
       <div className="overflow-y-auto overflow-x-hidden max-h={[`calc(100dvh-140px)`]} pt-0 pb-16 relative scrollbar-hide">
         {mode === 'teacher' && onToggleMenu && (
           <>

--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -74,9 +74,9 @@ const HomeworkCard = ({
     if (!el) return
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (!entry.isIntersecting) pauseYouTubeIframes(el)
+        if (entry.intersectionRatio < 0.5) pauseYouTubeIframes(el)
       },
-      { threshold: 0 }
+      { threshold: [0, 0.5, 1] }
     )
     observer.observe(el)
     return () => observer.disconnect()

--- a/client/src/components/TextEditor.tsx
+++ b/client/src/components/TextEditor.tsx
@@ -12,7 +12,6 @@ type Props = {
 }
 
 const TextEditor = ({ value, onChange, placeholder }: Props) => {
-  const skipNextUpdate = useRef(false)
   const savedSelection = useRef<{ from: number; to: number } | null>(null)
   const [linkDialog, setLinkDialog] = useState<{ url: string; text: string } | null>(null)
 
@@ -27,10 +26,6 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     ],
     content: value,
     onUpdate: ({ editor }) => {
-      if (skipNextUpdate.current) {
-        skipNextUpdate.current = false
-        return
-      }
       onChange(editor.isEmpty ? '' : editor.getHTML())
     },
   })
@@ -48,13 +43,13 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     }),
   })
 
-  // Sync when value is changed externally (e.g. form reset or initial load)
+  // Sync external value changes without triggering onChange
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
+    if (editor.isFocused) return
     const current = editor.getHTML()
     if (current !== value) {
-      skipNextUpdate.current = true
-      editor.commands.setContent(value)
+      editor.commands.setContent(value, { emitUpdate: false })
     }
   }, [value, editor])
 

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -49,3 +49,13 @@ export const processYouTubeEmbeds = (html: string): string => {
 
   return doc.body.innerHTML
 }
+
+export const pauseYouTubeIframes = (container: HTMLElement): void => {
+  container.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
+    if (!iframe.src.includes('youtube-nocookie.com')) return
+    iframe.contentWindow?.postMessage(
+      JSON.stringify({ event: 'command', func: 'pauseVideo', args: [] }),
+      '*'
+    )
+  })
+}

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -38,7 +38,7 @@ export const processYouTubeEmbeds = (html: string): string => {
     if (!videoId) return
 
     const iframe = doc.createElement('iframe')
-    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}`
+    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1`
     iframe.title = anchor.textContent?.trim() || 'YouTube video'
     iframe.loading = 'lazy'
     iframe.allowFullscreen = true

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -52,10 +52,17 @@ export const processYouTubeEmbeds = (html: string): string => {
 
 export const pauseYouTubeIframes = (container: HTMLElement): void => {
   container.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
-    if (!iframe.src.includes('youtube-nocookie.com')) return
+    let origin: string
+    try {
+      const url = new URL(iframe.src)
+      if (url.hostname !== 'www.youtube-nocookie.com') return
+      origin = url.origin
+    } catch {
+      return
+    }
     iframe.contentWindow?.postMessage(
       JSON.stringify({ event: 'command', func: 'pauseVideo', args: [] }),
-      '*'
+      origin
     )
   })
 }


### PR DESCRIPTION
Fixes YouTube videos continuing to play when navigating to another homework assignment, and a bug where pasting a single URL into an empty comment saved an empty homework.

**Key changes:**

- Enabled YouTube IFrame API on embedded videos
- Added `pauseYouTubeIframes` utility in `youtubeEmbed.ts`
- Added an `IntersectionObserver` in `HomeworkCard.tsx` to pause videos when navigating away
- Fixed a bug where pasting a single URL into an empty comment editor saved the homework with an empty comment

Closes #127