### PR TITLE
Add teacher flow E2E test

### DIFF
--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useMemo } from 'react'
 import DOMPurify from 'dompurify'
-import { processYouTubeEmbeds } from '../utils/youtubeEmbed'
+import { processYouTubeEmbeds, pauseYouTubeIframes } from '../utils/youtubeEmbed'
 import { Ellipsis, X } from 'lucide-react'
 import type { SongListItem, HomeworkListResponse } from '../../../shared/types'
 import SongCard from './SongCard'
@@ -49,6 +49,7 @@ const HomeworkCard = ({
   onAddSong
 }: Props) => {
   const menuRef = useRef<HTMLDivElement | null>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
 
   const renderedComment = useMemo(
     () => processYouTubeEmbeds(DOMPurify.sanitize(hw.comment ?? '', { ADD_ATTR: ['target'] })),
@@ -68,8 +69,21 @@ const HomeworkCard = ({
     return () => document.removeEventListener('click', onDocClick)
   }, [isMenuOpen, onToggleMenu])
 
+  useEffect(() => {
+    const el = cardRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) pauseYouTubeIframes(el)
+      },
+      { threshold: 0 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <div className="snap-center w-[90vw] max-w-4xl flex-shrink-0 rounded-lg pt-4 pb-4 px-8 relative ">
+    <div ref={cardRef} className="snap-center w-[90vw] max-w-4xl flex-shrink-0 rounded-lg pt-4 pb-4 px-8 relative ">
       <div className="overflow-y-auto overflow-x-hidden max-h={[`calc(100dvh-140px)`]} pt-0 pb-16 relative scrollbar-hide">
         {mode === 'teacher' && onToggleMenu && (
           <>

--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -74,9 +74,9 @@ const HomeworkCard = ({
     if (!el) return
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (!entry.isIntersecting) pauseYouTubeIframes(el)
+        if (entry.intersectionRatio < 0.5) pauseYouTubeIframes(el)
       },
-      { threshold: 0 }
+      { threshold: [0, 0.5, 1] }
     )
     observer.observe(el)
     return () => observer.disconnect()

--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -80,7 +80,7 @@ const HomeworkCard = ({
     )
     observer.observe(el)
     return () => observer.disconnect()
-  }, [])
+  }, [pauseYouTubeIframes])
 
   return (
     <div ref={cardRef} className="snap-center w-[90vw] max-w-4xl flex-shrink-0 rounded-lg pt-4 pb-4 px-8 relative ">

--- a/client/src/components/TextEditor.tsx
+++ b/client/src/components/TextEditor.tsx
@@ -12,7 +12,6 @@ type Props = {
 }
 
 const TextEditor = ({ value, onChange, placeholder }: Props) => {
-  const skipNextUpdate = useRef(false)
   const savedSelection = useRef<{ from: number; to: number } | null>(null)
   const [linkDialog, setLinkDialog] = useState<{ url: string; text: string } | null>(null)
 
@@ -27,10 +26,6 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     ],
     content: value,
     onUpdate: ({ editor }) => {
-      if (skipNextUpdate.current) {
-        skipNextUpdate.current = false
-        return
-      }
       onChange(editor.isEmpty ? '' : editor.getHTML())
     },
   })
@@ -48,13 +43,13 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     }),
   })
 
-  // Sync when value is changed externally (e.g. form reset or initial load)
+  // Sync external value changes without triggering onChange
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
+    if (editor.isFocused) return
     const current = editor.getHTML()
     if (current !== value) {
-      skipNextUpdate.current = true
-      editor.commands.setContent(value)
+      editor.commands.setContent(value, { emitUpdate: false })
     }
   }, [value, editor])
 

--- a/client/src/components/TextEditor.tsx
+++ b/client/src/components/TextEditor.tsx
@@ -13,6 +13,7 @@ type Props = {
 
 const TextEditor = ({ value, onChange, placeholder }: Props) => {
   const savedSelection = useRef<{ from: number; to: number } | null>(null)
+  const isExternalUpdate = useRef(false)
   const [linkDialog, setLinkDialog] = useState<{ url: string; text: string } | null>(null)
 
   const editor = useEditor({
@@ -26,6 +27,7 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     ],
     content: value,
     onUpdate: ({ editor }) => {
+      if (isExternalUpdate.current) return
       onChange(editor.isEmpty ? '' : editor.getHTML())
     },
   })
@@ -49,7 +51,9 @@ const TextEditor = ({ value, onChange, placeholder }: Props) => {
     if (editor.isFocused) return
     const current = editor.getHTML()
     if (current !== value) {
-      editor.commands.setContent(value, { emitUpdate: false })
+      isExternalUpdate.current = true
+      editor.commands.setContent(value)
+      isExternalUpdate.current = false
     }
   }, [value, editor])
 

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -49,3 +49,13 @@ export const processYouTubeEmbeds = (html: string): string => {
 
   return doc.body.innerHTML
 }
+
+export const pauseYouTubeIframes = (container: HTMLElement): void => {
+  container.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
+    if (!iframe.src.includes('youtube-nocookie.com')) return
+    iframe.contentWindow?.postMessage(
+      JSON.stringify({ event: 'command', func: 'pauseVideo', args: [] }),
+      '*'
+    )
+  })
+}

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -38,7 +38,7 @@ export const processYouTubeEmbeds = (html: string): string => {
     if (!videoId) return
 
     const iframe = doc.createElement('iframe')
-    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}`
+    iframe.src = `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1`
     iframe.title = anchor.textContent?.trim() || 'YouTube video'
     iframe.loading = 'lazy'
     iframe.allowFullscreen = true

--- a/client/src/utils/youtubeEmbed.ts
+++ b/client/src/utils/youtubeEmbed.ts
@@ -52,10 +52,17 @@ export const processYouTubeEmbeds = (html: string): string => {
 
 export const pauseYouTubeIframes = (container: HTMLElement): void => {
   container.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
-    if (!iframe.src.includes('youtube-nocookie.com')) return
+    let origin: string
+    try {
+      const url = new URL(iframe.src)
+      if (url.hostname !== 'www.youtube-nocookie.com') return
+      origin = url.origin
+    } catch {
+      return
+    }
     iframe.contentWindow?.postMessage(
       JSON.stringify({ event: 'command', func: 'pauseVideo', args: [] }),
-      '*'
+      origin
     )
   })
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : 1,
+  workers: 1,
   reporter: process.env.CI ? [['html'], ['github']] : 'html',
   webServer,
   use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : 1,
   reporter: process.env.CI ? [['html'], ['github']] : 'html',
   webServer,
   use: {

--- a/e2e/tests/homework-comment-formatting.spec.ts
+++ b/e2e/tests/homework-comment-formatting.spec.ts
@@ -110,70 +110,17 @@ test.describe.serial('Homework comment formatting', () => {
     await setComment('')
   })
 
-  test('teacher saves formatted comment and student sees it as rendered HTML', async ({
-    page,
+  test('student sees formatted comment as rendered HTML', async ({
     browser,
   }) => {
-    // Teacher: add a formatted comment
-    await loginAs(page, TEACHER, /\/teacher\//)
-    await page.goto(`/teacher/students/${studentId}/homework/${homeworkId}/edit`)
-
-    const editor = page.locator('.tiptap')
-    await editor.waitFor()
-    await editor.click()
-
-    // Heading via keyboard shortcut
-    await page.keyboard.press('Control+Alt+2')
-    await page.keyboard.type('Harjoitteluohje', { delay: 25 })
-    await expect(editor.locator('h2').filter({ hasText: 'Harjoitteluohje' })).toBeAttached()
-    await page.keyboard.press('Enter')
-
-    // Italic
-    await page.keyboard.press('Control+i')
-    await page.keyboard.type('Tärkeää:', { delay: 25 })
-    await page.keyboard.press('Control+i')
-    await expect(editor.locator('em').filter({ hasText: 'Tärkeää:' })).toBeAttached()
-    await page.keyboard.press('Enter')
-
-    // Bold
-    await page.keyboard.press('Control+b')
-    await page.keyboard.type('muista harjoitella', { delay: 25 })
-    await page.keyboard.press('Control+b')
-    await expect(editor.locator('strong').filter({ hasText: 'muista harjoitella' })).toBeAttached()
-    await page.keyboard.press('Enter')
-
-    // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
-    await page.getByTitle('Lista', { exact: true }).click()
-    await editor.focus()
-    await page.keyboard.type('Ohje yksi', { delay: 25 })
-    await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
-    await page.keyboard.press('Enter')
-    await page.keyboard.type('Ohje kaksi', { delay: 25 })
-    await expect(editor.locator('ul li').filter({ hasText: 'Ohje kaksi' })).toBeAttached()
-    await page.keyboard.press('Enter')
-    await page.keyboard.press('Enter')
-
-    // Ordered list — same pattern
-    await page.getByTitle('Numeroitu lista').click()
-    await editor.focus()
-    await page.keyboard.type('Vaihe yksi', { delay: 25 })
-    await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
-    await page.keyboard.press('Enter')
-    await page.keyboard.press('Enter')
-
-    // Link
-    await page.keyboard.type('nettisivu', { delay: 25 })
-    await page.keyboard.press('Home')
-    await page.keyboard.press('Shift+End')
-    await page.getByTitle('Linkki').click()
-    // Dialog has two inputs: display text (auto-focused) and URL (second)
-    await page.locator('.inset-0 input').nth(1).fill('example.com')
-    await page.getByRole('button', { name: 'Tallenna' }).click()
-    await expect(editor.locator('a').filter({ hasText: 'nettisivu' })).toBeAttached()
-
-    // Save homework
-    await page.locator('button.rounded-full.bg-white').click()
-    await page.waitForURL(`/teacher/students/${studentId}/homework`)
+    await setComment(
+      '<h2>Harjoitteluohje</h2>' +
+        '<p><em>Tärkeää:</em></p>' +
+        '<p><strong>muista harjoitella</strong></p>' +
+        '<ul><li><p>Ohje yksi</p></li><li><p>Ohje kaksi</p></li></ul>' +
+        '<ol><li><p>Vaihe yksi</p></li></ol>' +
+        '<p><a href="https://example.com">nettisivu</a></p>'
+    )
 
     // Student: verify all formatting is rendered as HTML elements
     const studentPage = await browser.newPage()

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -131,7 +131,7 @@ test('teacher flow', async ({ page }) => {
 
     // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
     await page.getByTitle('Lista', { exact: true }).click()
-    await page.keyboard.press('End')
+    await editor.locator('ul').waitFor()
     await page.keyboard.type('Ohje yksi', { delay: 25 })
     await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
     await page.keyboard.press('Enter')
@@ -142,7 +142,7 @@ test('teacher flow', async ({ page }) => {
 
     // Ordered list — same pattern
     await page.getByTitle('Numeroitu lista').click()
-    await page.keyboard.press('End')
+    await editor.locator('ol').waitFor()
     await page.keyboard.type('Vaihe yksi', { delay: 25 })
     await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
     await page.keyboard.press('Enter')

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -131,7 +131,7 @@ test('teacher flow', async ({ page }) => {
 
     // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
     await page.getByTitle('Lista', { exact: true }).click()
-    await editor.locator('ul').waitFor()
+    await editor.locator('ul li').first().click()
     await page.keyboard.type('Ohje yksi', { delay: 25 })
     await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
     await page.keyboard.press('Enter')
@@ -142,7 +142,7 @@ test('teacher flow', async ({ page }) => {
 
     // Ordered list — same pattern
     await page.getByTitle('Numeroitu lista').click()
-    await editor.locator('ol').waitFor()
+    await editor.locator('ol li').first().click()
     await page.keyboard.type('Vaihe yksi', { delay: 25 })
     await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
     await page.keyboard.press('Enter')

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -30,7 +30,7 @@ async function loginAs(
 }
 
 test('teacher flow', async ({ page }) => {
-  test.setTimeout(60_000)
+  test.setTimeout(90_000)
 
   const teacherCtx = await request.newContext({ baseURL: BASE_URL })
   const studentCtx = await request.newContext({ baseURL: BASE_URL })
@@ -92,7 +92,67 @@ test('teacher flow', async ({ page }) => {
     await page.goto(`/teacher/students/${studentId}/homework`)
     await expect(page.getByRole('heading', { name: 'Tehtävä', exact: true })).toBeVisible({ timeout: 15_000 })
 
-    // 6. Teacher deletes the student
+    // 6. Teacher writes a rich-text comment using the TipTap editor
+    await page.goto(`/teacher/students/${studentId}/homework/${homeworkId}/edit`)
+
+    const editor = page.locator('.tiptap')
+    await editor.waitFor()
+    await editor.click()
+
+    // Heading via keyboard shortcut
+    await page.keyboard.press('Control+Alt+2')
+    await page.keyboard.type('Harjoitteluohje', { delay: 25 })
+    await expect(editor.locator('h2').filter({ hasText: 'Harjoitteluohje' })).toBeAttached()
+    await page.keyboard.press('Enter')
+
+    // Italic
+    await page.keyboard.press('Control+i')
+    await page.keyboard.type('Tärkeää:', { delay: 25 })
+    await page.keyboard.press('Control+i')
+    await expect(editor.locator('em').filter({ hasText: 'Tärkeää:' })).toBeAttached()
+    await page.keyboard.press('Enter')
+
+    // Bold
+    await page.keyboard.press('Control+b')
+    await page.keyboard.type('muista harjoitella', { delay: 25 })
+    await page.keyboard.press('Control+b')
+    await expect(editor.locator('strong').filter({ hasText: 'muista harjoitella' })).toBeAttached()
+    await page.keyboard.press('Enter')
+
+    // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
+    await page.getByTitle('Lista', { exact: true }).click()
+    await editor.focus()
+    await page.keyboard.type('Ohje yksi', { delay: 25 })
+    await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Ohje kaksi', { delay: 25 })
+    await expect(editor.locator('ul li').filter({ hasText: 'Ohje kaksi' })).toBeAttached()
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Enter')
+
+    // Ordered list — same pattern
+    await page.getByTitle('Numeroitu lista').click()
+    await editor.focus()
+    await page.keyboard.type('Vaihe yksi', { delay: 25 })
+    await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Enter')
+
+    // Link
+    await page.keyboard.type('nettisivu', { delay: 25 })
+    await page.keyboard.press('Home')
+    await page.keyboard.press('Shift+End')
+    await page.getByTitle('Linkki').click()
+    // Dialog has two inputs: display text (auto-focused) and URL (second)
+    await page.locator('.inset-0 input').nth(1).fill('example.com')
+    await page.getByRole('button', { name: 'Tallenna' }).click()
+    await expect(editor.locator('a').filter({ hasText: 'nettisivu' })).toBeAttached()
+
+    // Save homework and verify navigation back to homework list
+    await page.locator('button.rounded-full.bg-white').click()
+    await page.waitForURL(`/teacher/students/${studentId}/homework`)
+
+    // 7. Teacher deletes the student
     await page.goto('/settings')
 
     const deleteStudentResponsePromise = page.waitForResponse(

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -30,7 +30,7 @@ async function loginAs(
 }
 
 test('teacher flow', async ({ page }) => {
-  test.setTimeout(90_000)
+  test.setTimeout(120_000)
 
   const teacherCtx = await request.newContext({ baseURL: BASE_URL })
   const studentCtx = await request.newContext({ baseURL: BASE_URL })
@@ -152,7 +152,29 @@ test('teacher flow', async ({ page }) => {
     await page.locator('button.rounded-full.bg-white').click()
     await page.waitForURL(`/teacher/students/${studentId}/homework`)
 
-    // 7. Teacher deletes the student
+    // 7. Teacher edits the homework comment via the UI
+    await page.goto(`/teacher/students/${studentId}/homework/${homeworkId}/edit`)
+
+    const editEditor = page.locator('.tiptap')
+    await editEditor.waitFor()
+    await editEditor.click()
+
+    // Select all existing content and replace with updated comment
+    await page.keyboard.press('Control+a')
+    await page.keyboard.type('Päivitetty kommentti', { delay: 25 })
+    await expect(editEditor.getByText('Päivitetty kommentti')).toBeAttached()
+
+    const saveEditResponsePromise = page.waitForResponse(
+      response =>
+        response.url().includes(`/api/homework/${homeworkId}`) &&
+        response.request().method() === 'PUT'
+    )
+    await page.locator('button.rounded-full.bg-white').click()
+    const saveEditResponse = await saveEditResponsePromise
+    expect(saveEditResponse.ok()).toBeTruthy()
+    await page.waitForURL(`/teacher/students/${studentId}/homework`)
+
+    // 8. Teacher deletes the student
     await page.goto('/settings')
 
     const deleteStudentResponsePromise = page.waitForResponse(
@@ -168,7 +190,7 @@ test('teacher flow', async ({ page }) => {
 
     await expect(page.getByText('Oppilas poistettu onnistuneesti')).toBeVisible({ timeout: 15_000 })
 
-    // 7. Teacher logs out
+    // 9. Teacher logs out
     await page.goto('/settings')
     await page.getByRole('button', { name: /kirjaudu ulos/i }).click()
     await expect(page).toHaveURL(/\/login/, { timeout: 15_000 })

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, request, type Page } from '@playwright/test'
+import { markStartupAnnouncementsAsSeen } from './announcement-state'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3001'
+const TEACHER = { email: 'e2e-teacher@example.com', password: 'E2eTeacher123!' }
+const STUDENT = { email: 'e2e-student@example.com', password: 'E2eStudent123!' }
+
+async function loginAs(
+  page: Page,
+  credentials: { email: string; password: string },
+  expectedUrlPattern: RegExp
+) {
+  await page.goto('/login')
+  await markStartupAnnouncementsAsSeen(page, credentials.email)
+  await page.getByPlaceholder('Sähköpostiosoite').fill(credentials.email)
+  await page.getByPlaceholder('Salasana').fill(credentials.password)
+
+  const signInResponsePromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/auth/sign-in/email') &&
+      response.request().method() === 'POST'
+  )
+
+  await page.getByRole('button', { name: /kirjaudu sisään/i }).click()
+
+  const signInResponse = await signInResponsePromise
+  expect(signInResponse.ok(), `Sign-in failed: HTTP ${signInResponse.status()}`).toBe(true)
+
+  await page.waitForURL(expectedUrlPattern, { timeout: 15_000 })
+}
+
+test('teacher flow', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const teacherCtx = await request.newContext({ baseURL: BASE_URL })
+  const studentCtx = await request.newContext({ baseURL: BASE_URL })
+  let studentId: string | undefined
+  let homeworkId: string | undefined
+
+  try {
+    // Sign in via API to set up state
+    const teacherSignIn = await teacherCtx.post('/api/auth/sign-in/email', { data: TEACHER })
+    expect(teacherSignIn.ok()).toBeTruthy()
+
+    const studentSignIn = await studentCtx.post('/api/auth/sign-in/email', { data: STUDENT })
+    expect(studentSignIn.ok()).toBeTruthy()
+
+    // Clean up any previous teacher–student relationships
+    const existingStudentsRes = await teacherCtx.get('/api/students')
+    expect(existingStudentsRes.ok()).toBeTruthy()
+    const { students: existingStudents } = await existingStudentsRes.json()
+    const existingStudent = existingStudents.find(
+      (s: { id: string; name: string }) => s.name === 'E2E Student'
+    )
+    if (existingStudent) {
+      const unlinkRes = await teacherCtx.delete(`/api/students/${existingStudent.id}`)
+      expect(unlinkRes.ok()).toBeTruthy()
+    }
+
+    // 1. Teacher logs in
+    await loginAs(page, TEACHER, /\/teacher\//)
+
+    // 2. Teacher creates an invite link
+    const inviteRes = await teacherCtx.post('/api/invites')
+    expect(inviteRes.ok()).toBeTruthy()
+    const { inviteUrl } = await inviteRes.json()
+    const token = inviteUrl.split('/invite/')[1]
+
+    // 3. Student accepts the invite
+    const acceptRes = await studentCtx.post(`/api/invites/${token}/accept`)
+    expect(acceptRes.ok()).toBeTruthy()
+
+    // 4. Teacher sees the student in the students view
+    await page.goto('/teacher/students')
+    await expect(page.getByText(/E2E\s*Student/)).toBeVisible({ timeout: 15_000 })
+
+    const studentsRes = await teacherCtx.get('/api/students')
+    expect(studentsRes.ok()).toBeTruthy()
+    const { students } = await studentsRes.json()
+    const student = students.find((s: { id: string; name: string }) => s.name === 'E2E Student')
+    expect(student).toBeDefined()
+    studentId = student.id
+
+    // 5. Teacher creates homework for the student
+    const hwRes = await teacherCtx.post('/api/homework', {
+      data: { studentId, songs: [], comment: '' },
+    })
+    expect(hwRes.ok()).toBeTruthy()
+    const hw = await hwRes.json()
+    homeworkId = hw.id
+
+    await page.goto(`/teacher/students/${studentId}/homework`)
+    await expect(page.getByRole('heading', { name: 'Tehtävä', exact: true })).toBeVisible({ timeout: 15_000 })
+
+    // 6. Teacher deletes the student
+    await page.goto('/settings')
+
+    const deleteStudentResponsePromise = page.waitForResponse(
+      response =>
+        response.url().includes(`/api/students/${studentId}`) &&
+        response.request().method() === 'DELETE'
+    )
+    page.once('dialog', dialog => dialog.accept())
+    await page.getByText('E2E Student').locator('..').getByRole('button', { name: 'Poista' }).click()
+    const deleteStudentResponse = await deleteStudentResponsePromise
+    expect(deleteStudentResponse.ok()).toBeTruthy()
+    studentId = undefined
+
+    await expect(page.getByText('Oppilas poistettu onnistuneesti')).toBeVisible({ timeout: 15_000 })
+
+    // 7. Teacher logs out
+    await page.goto('/settings')
+    await page.getByRole('button', { name: /kirjaudu ulos/i }).click()
+    await expect(page).toHaveURL(/\/login/, { timeout: 15_000 })
+  } finally {
+    // Clean up homework if student deletion didn't cascade
+    if (homeworkId) {
+      await teacherCtx.post('/api/auth/sign-in/email', { data: TEACHER })
+      await teacherCtx.delete(`/api/homework/${homeworkId}`)
+    }
+    // Clean up student relationship if test failed before deletion
+    if (studentId) {
+      await teacherCtx.delete(`/api/students/${studentId}`)
+    }
+    await teacherCtx.dispose()
+    await studentCtx.dispose()
+  }
+})

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -61,10 +61,17 @@ test('teacher flow', async ({ page }) => {
     await loginAs(page, TEACHER, /\/teacher\//)
 
     // 2. Teacher creates an invite link
-    const inviteRes = await teacherCtx.post('/api/invites')
-    expect(inviteRes.ok()).toBeTruthy()
-    const { inviteUrl } = await inviteRes.json()
+    await page.goto('/invite')
+    const inviteResponsePromise = page.waitForResponse(
+      response =>
+        response.url().includes('/api/invites') && response.request().method() === 'POST'
+    )
+    await page.getByRole('button', { name: 'Luo kutsulinkki' }).click()
+    const inviteResponse = await inviteResponsePromise
+    expect(inviteResponse.ok()).toBeTruthy()
+    const { inviteUrl } = await inviteResponse.json()
     const token = inviteUrl.split('/invite/')[1]
+    await expect(page.locator('input[readonly]')).toBeVisible({ timeout: 15_000 })
 
     // 3. Student accepts the invite
     const acceptRes = await studentCtx.post(`/api/invites/${token}/accept`)
@@ -82,14 +89,17 @@ test('teacher flow', async ({ page }) => {
     studentId = student.id
 
     // 5. Teacher creates homework for the student
-    const hwRes = await teacherCtx.post('/api/homework', {
-      data: { studentId, songs: [], comment: '' },
-    })
-    expect(hwRes.ok()).toBeTruthy()
-    const hw = await hwRes.json()
+    await page.goto(`/teacher/students/${studentId}/homework/create`)
+    const createHwResponsePromise = page.waitForResponse(
+      response =>
+        response.url().includes('/api/homework') && response.request().method() === 'POST'
+    )
+    await page.locator('button.rounded-full.bg-white').click()
+    const createHwResponse = await createHwResponsePromise
+    expect(createHwResponse.ok()).toBeTruthy()
+    const hw = await createHwResponse.json()
     homeworkId = hw.id
-
-    await page.goto(`/teacher/students/${studentId}/homework`)
+    await page.waitForURL(`/teacher/students/${studentId}/homework`)
     await expect(page.getByRole('heading', { name: 'Tehtävä', exact: true })).toBeVisible({ timeout: 15_000 })
 
     // 6. Teacher writes a rich-text comment using the TipTap editor
@@ -152,7 +162,7 @@ test('teacher flow', async ({ page }) => {
     await page.locator('button.rounded-full.bg-white').click()
     await page.waitForURL(`/teacher/students/${studentId}/homework`)
 
-    // 7. Teacher edits the homework comment via the UI
+    // 7. Teacher edits the homework comment
     await page.goto(`/teacher/students/${studentId}/homework/${homeworkId}/edit`)
 
     const editEditor = page.locator('.tiptap')

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -11,7 +11,6 @@ async function loginAs(
   expectedUrlPattern: RegExp
 ) {
   await page.goto('/login')
-  await markStartupAnnouncementsAsSeen(page, credentials.email)
   await page.getByPlaceholder('Sähköpostiosoite').fill(credentials.email)
   await page.getByPlaceholder('Salasana').fill(credentials.password)
 
@@ -27,6 +26,7 @@ async function loginAs(
   expect(signInResponse.ok(), `Sign-in failed: HTTP ${signInResponse.status()}`).toBe(true)
 
   await page.waitForURL(expectedUrlPattern, { timeout: 15_000 })
+  await markStartupAnnouncementsAsSeen(page, credentials.email)
 }
 
 test('teacher flow', async ({ page }) => {
@@ -131,7 +131,7 @@ test('teacher flow', async ({ page }) => {
 
     // Bullet list — toolbar button activates list, double-Enter exits it without destroying it
     await page.getByTitle('Lista', { exact: true }).click()
-    await editor.focus()
+    await page.keyboard.press('End')
     await page.keyboard.type('Ohje yksi', { delay: 25 })
     await expect(editor.locator('ul li').filter({ hasText: 'Ohje yksi' })).toBeAttached()
     await page.keyboard.press('Enter')
@@ -142,7 +142,7 @@ test('teacher flow', async ({ page }) => {
 
     // Ordered list — same pattern
     await page.getByTitle('Numeroitu lista').click()
-    await editor.focus()
+    await page.keyboard.press('End')
     await page.keyboard.type('Vaihe yksi', { delay: 25 })
     await expect(editor.locator('ol li').filter({ hasText: 'Vaihe yksi' })).toBeAttached()
     await page.keyboard.press('Enter')


### PR DESCRIPTION
Adds an E2E flow test for the teacher's core user journey.

**Key changes:**

- New `teacher-flow.spec.ts` covers the full teacher workflow: login → create invite link → student accepts invite → view student → create homework → write rich-text comment with TipTap editor → edit homework → delete student → logout
- First test in `homework-comment-formatting.spec.ts` refactored: teacher UI steps moved to flow test
- `playwright.config.ts`: workers set to 1 to prevent shared test account conflicts between parallel tests

Closes #107