### PR TITLE
Remove unnecessary title from homework carousel

### DIFF
--- a/client/src/components/HomeworkCard.tsx
+++ b/client/src/components/HomeworkCard.tsx
@@ -125,12 +125,7 @@ const HomeworkCard = ({
           </>
         )}
 
-        <h2 className="mb-1">
-          {headingLabel ?? (isLatest ? 'Tehtävä' : 'Arkistoitu tehtävä')}
-        </h2>
-        <p className="text-xs text-gray-300 mb-12">
-          {new Date(hw.createdAt).toLocaleDateString()}
-        </p>
+        <h2 className="mb-1">{headingLabel ?? new Date(hw.createdAt).toLocaleDateString()}</h2>
 
         {hw.songs.map(songId => {
           const song = songMap.get(songId)

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -77,6 +77,8 @@ export default defineConfig({
     baseURL: isCI ? serverUrl : uiUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    locale: 'fi-FI',
+    timezoneId: 'Europe/Helsinki',
   },
   projects: [
     {

--- a/e2e/tests/teacher-flow.spec.ts
+++ b/e2e/tests/teacher-flow.spec.ts
@@ -34,6 +34,12 @@ test('teacher flow', async ({ page }) => {
 
   const teacherCtx = await request.newContext({ baseURL: BASE_URL })
   const studentCtx = await request.newContext({ baseURL: BASE_URL })
+  const today = new Date()
+  const expectedDateText = today.toLocaleDateString('fi-FI', {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric'
+  })
   let studentId: string | undefined
   let homeworkId: string | undefined
   let hw2Id: string | undefined
@@ -127,7 +133,7 @@ test('teacher flow', async ({ page }) => {
     const hw = await createHwResponse.json()
     homeworkId = hw.id
     await page.waitForURL(`/teacher/students/${studentId}/homework`)
-    await expect(page.getByRole('heading', { name: 'Tehtävä', exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(expectedDateText).first()).toBeVisible({ timeout: 15_000 })
 
     // 6. Teacher creates a second homework via API to enable carousel navigation
     const createHw2Res = await teacherCtx.post('/api/homework', {
@@ -139,7 +145,7 @@ test('teacher flow', async ({ page }) => {
 
     // 7. Carousel navigation: arrows and dot indicator appear with 2 homeworks
     await page.goto(`/teacher/students/${studentId}/homework`)
-    await expect(page.getByRole('heading', { name: 'Tehtävä', exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(expectedDateText).first()).toBeVisible({ timeout: 15_000 })
 
     const leftArrow = page.getByRole('button', { name: 'Edellinen kotitehtävä' })
     const rightArrow = page.getByRole('button', { name: 'Seuraava kotitehtävä' })


### PR DESCRIPTION
Removed "Tehtäväsi" and "Arkistoitu tehtävä" titles and replaced it with the date of the homework