### PR TITLE
Show homework icon as active on all homework pages

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -41,7 +41,14 @@ export const Navbar = () => {
         )}
 
         {(userType === 'student' || isAdminRegularUserView) && (
-          <Link to={lastRoute} className={isActive(lastRoute)}>
+          <Link
+            to={lastRoute}
+            className={
+              location.pathname.startsWith('/student/homework')
+                ? 'text-white'
+                : 'text-gray-500'
+            }
+          >
             <BookOpenText className="w-6 h-6" />
           </Link>
         )}


### PR DESCRIPTION
Fixes the homework navbar icon not appearing as active when navigating back from the homework list to the homework start page.

**Key changes:**

- Changed the active state check in `Navbar.tsx` from matching only `/student/homework/list` to matching any path starting with `/student/homework`

Closes #152