### PR TITLE
Remove counting the change of student/teacher users since last log in from the admin dashboard

### DIFF
--- a/client/src/components/AdminDashboardPage.tsx
+++ b/client/src/components/AdminDashboardPage.tsx
@@ -5,11 +5,6 @@ import { adminService } from '../services/admin'
 import type { AdminPopupMessage } from '../services/admin'
 import { ADMIN_POPUPS_UPDATED_EVENT } from '../utils/adminPopupEvents'
 
-const formatDelta = (value: number) => {
-  if (value > 0) return `+${value}`
-  return `${value}`
-}
-
 const popupAudienceLabel = (message: AdminPopupMessage) => {
   const visibleToTeachers = message.visibleToTeachers !== false
   const visibleToStudents = message.visibleToStudents !== false
@@ -24,8 +19,6 @@ export const AdminDashboardPage = () => {
   const { data: summary } = useAdminSummary({ refetchInterval: 30000 })
   const { data: feedbackData } = useAdminFeedbacks({ refetchInterval: 30000 })
   const [messages, setMessages] = useState<AdminPopupMessage[]>([])
-  const [baselineTeacherCount, setBaselineTeacherCount] = useState<number | null>(null)
-  const [baselineStudentCount, setBaselineStudentCount] = useState<number | null>(null)
 
   const fetchMessages = useCallback(async () => {
     const response = await adminService.getAdminPopupMessages()
@@ -49,20 +42,8 @@ export const AdminDashboardPage = () => {
     }
   }, [fetchMessages])
 
-  useEffect(() => {
-    if (!summary) return
-    if (baselineTeacherCount === null) {
-      setBaselineTeacherCount(summary.teacherCount)
-    }
-    if (baselineStudentCount === null) {
-      setBaselineStudentCount(summary.studentCount)
-    }
-  }, [summary, baselineTeacherCount, baselineStudentCount])
-
   const teacherCount = summary?.teacherCount ?? 0
   const studentCount = summary?.studentCount ?? 0
-  const teacherDelta = baselineTeacherCount === null ? 0 : teacherCount - baselineTeacherCount
-  const studentDelta = baselineStudentCount === null ? 0 : studentCount - baselineStudentCount
   const unreadFeedbackCount = (feedbackData?.feedbacks ?? []).filter(item => !item.isRead).length
   const activePopups = messages.filter(
     message =>
@@ -92,7 +73,6 @@ export const AdminDashboardPage = () => {
             Opettajat
           </h3>
           <p className="mt-1 text-center text-2xl font-bold md:text-3xl">{teacherCount}</p>
-          <p className="mt-1 text-center text-xs text-gray-400">Muutos: {formatDelta(teacherDelta)}</p>
         </div>
 
         <div className="rounded-lg bg-neutral-900 p-4">
@@ -101,7 +81,6 @@ export const AdminDashboardPage = () => {
             Oppilaat
           </h3>
           <p className="mt-1 text-center text-2xl font-bold md:text-3xl">{studentCount}</p>
-          <p className="mt-1 text-center text-xs text-gray-400">Muutos: {formatDelta(studentDelta)}</p>
         </div>
       </div>
 

--- a/client/src/components/PopupAdminPage.tsx
+++ b/client/src/components/PopupAdminPage.tsx
@@ -551,7 +551,7 @@ export const PopupAdminPage = () => {
                   : 'bg-emerald-800 text-emerald-100'
               }`}
             >
-              {isDraft ? 'Luonnos' : 'Julkaistu'}
+              Julkaistu
             </span>
             <button
               type="button"
@@ -834,7 +834,7 @@ export const PopupAdminPage = () => {
                                 : 'bg-emerald-800 text-emerald-100'
                             }`}
                           >
-                            {editIsDraft ? 'Luonnos' : 'Julkaistu'}
+                            Julkaistu
                           </span>
                           <button
                             type="button"
@@ -895,7 +895,7 @@ export const PopupAdminPage = () => {
                                 : 'bg-emerald-800 text-emerald-100'
                             }`}
                           >
-                            {message.isDraft ? 'Luonnos' : 'Julkaistu'}
+                            {message.isDraft ? 'Luonnos' : 'Julkinen'}
                           </span>
                           <span className="text-xs px-2 py-1 rounded bg-neutral-700 text-neutral-100">
                             {audienceLabel(message)}
@@ -965,7 +965,7 @@ export const PopupAdminPage = () => {
                                 : 'bg-emerald-800 text-emerald-100'
                             }`}
                           >
-                            {message.isDraft ? 'Luonnos' : 'Julkaistu'}
+                            Julkaistu
                           </span>
                           <button
                             type="button"

--- a/client/src/components/SignUp.tsx
+++ b/client/src/components/SignUp.tsx
@@ -46,7 +46,7 @@ export const Signup = () => {
     }
 
     if (!passwordMeetsRequirements) {
-      showError(`Salasanan täytyy olla 8-128 merkkiä pitkä.`)
+      showError(`Salasanan täytyy olla vähintään 8 merkkiä pitkä.`)
       return
     }
 
@@ -116,7 +116,7 @@ export const Signup = () => {
                 : 'text-gray-300'
             }`}
           >
-            Salasanan täytyy olla 8-128 merkkiä pitkä.
+            Salasanan täytyy olla vähintään 8 merkkiä pitkä.
           </p>
         </div>
 


### PR DESCRIPTION
- removed the "Muutos: X" counter from the admin dashboard that showed the change of student/teacher users since last log in