### PR TITLE
Change back arrow to fixed instead of absolute

### DIFF
--- a/client/src/components/MusicPlayer.tsx
+++ b/client/src/components/MusicPlayer.tsx
@@ -336,7 +336,7 @@ const startPlayback = async () => {
     <div className="min-h-screen flex flex-col">
       <button
         onClick={handleBack}
-        className="absolute left-6 top-4 z-10 rounded-full bg-black/35 p-1 backdrop-blur-sm transition hover:bg-black/50"
+        className="fixed left-6 top-4 z-10 rounded-full bg-black/35 p-1 backdrop-blur-sm transition hover:bg-black/50"
         aria-label="Palaa takaisin"
       >
         <ArrowLeft className="w-8 h-8 text-white" />


### PR DESCRIPTION
Changed back arrow to be fixed instead of absolute OR sticky.
Chose fixed because easier accessibilty when scrolled down or screen is larger/smaller.